### PR TITLE
Dockerfile: switch to go 1.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build caddy from source, because binaries are published under a commercial license: https://caddyserver.com/pricing
-FROM golang:1.9.0 as caddybuild
+FROM golang:1.10.0 as caddybuild
 ARG CADDY_VERSION="0.10.10"
 RUN \
   git clone https://github.com/mholt/caddy /go/src/github.com/mholt/caddy \


### PR DESCRIPTION
caddyhttp has made some improvements and uses now the library versions
from go-1.10. Without this patch we get this errormessage:

    Cloning into '/go/src/github.com/mholt/caddy'...
    Switched to a new branch 'v0.10.10'
    github.com/caddyserver/builds (download)
    # github.com/mholt/caddy/caddyhttp/httpserver
    ../caddyhttp/httpserver/replacer.go:466:22: cert.Issuer.String undefined (type pkix.Name has no field or method String)
    ../caddyhttp/httpserver/replacer.go:478:23: cert.Subject.String undefined (type pkix.Name has no field or method String)

Signed-off-by: Silvio Fricke <silvio.fricke@gmail.com>